### PR TITLE
Update functions.py

### DIFF
--- a/gptorch/functions.py
+++ b/gptorch/functions.py
@@ -12,7 +12,7 @@ from torch.nn import functional as F
 import numpy as np
     
 
-def jit_op(op, x: torch.Tensor, max_tries: int=10, verbose: bool=True) \
+def jit_op(op, x: torch.Tensor, max_tries: int=10, verbose: bool=False) \
         -> torch.Tensor:
     """
     Attempt a potentially-unstable linear algebra operation on a matrix.


### PR DESCRIPTION
Sometimes, the kernel can train to a state where every linalg operation on the kernel matrices (e.g. Cholesky) fails without jitter.  When making lots of predictions, this can result in a lot of output cluttering stdout.

This PR makes verbose=False the default for jit_op().  If it fails after many tries, then we still get the error message.