### PR TITLE
Fix for `torch.potri` removed in torch 1.2.0

### DIFF
--- a/gptorch/densities.py
+++ b/gptorch/densities.py
@@ -4,7 +4,7 @@
 # class for probability density functions
 from __future__ import absolute_import
 from . import util as ut
-from .functions import cholesky, inverse
+from .functions import cholesky, inverse, cholesky_inverse
 
 import torch as th
 import numpy as np
@@ -355,7 +355,7 @@ class GaussianMultivariateFull(Density):
     def _get_precision(self):
         if self._l is None:
             self._get_chol()
-        self._precision = Variable(torch.potri(self._l.data))
+        self._precision = Variable(cholesky_inverse(self._l.data.t()))
 
     def _get_chol(self):
         self._l = cholesky(self.sigma).t()

--- a/gptorch/functions.py
+++ b/gptorch/functions.py
@@ -10,6 +10,9 @@ from .util import as_tensor
 import torch
 from torch.nn import functional as F
 import numpy as np
+
+torch_version = [int(s) for s in torch.__version__.split(".")]
+_potri = torch.cholesky_inverse if torch_version >= [1, 1, 0] else torch.potri
     
 
 def jit_op(op, x: torch.Tensor, max_tries: int=10, verbose: bool=False) \
@@ -39,6 +42,13 @@ def jit_op(op, x: torch.Tensor, max_tries: int=10, verbose: bool=False) \
 
 def cholesky(x: torch.Tensor) -> torch.Tensor:
     return jit_op(torch.cholesky, x)
+
+
+def cholesky_inverse(x: torch.Tensor, upper=False) -> torch.Tensor:
+    """
+    Inverse of a matrix based on its Cholesky.
+    """
+    return _potri(x, upper=upper)
 
 
 def inverse(x: torch.Tensor) -> torch.Tensor:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ requirements = [
 ]
 
 setup(name="gptorch",
-    version="0.2.1",
+    version="0.2.2",
     description="gptorch - a Gaussian process toolbox built on PyTorch",
     author="Yinhao Zhu, Steven Atkinson",
     author_email="yzhu10@nd.edu, satkinso@nd.edu",


### PR DESCRIPTION
`gptorch.densities.MultivariateGaussianFull` used `torch.potri`.  Now that this is removed from torch, fix by adding `functions.cholesky_inverse` and picking the correct `torch` function based on the detected version.  `upper` kwarg defaults to the new convention, as implied by the function name matching the new method `cholesky_inverse`.