### PR TITLE
Remove torch.set_default_dtype() from package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,16 @@
 # Python CircleCI 2.0 configuration file
-#
 # Check https://circleci.com/docs/2.0/language-python/ for more details
-#
 version: 2
 jobs:
   build:
     docker:
-      # specify the version you desire here
-      # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.1
-
-      # Specify service dependencies here if necessary
-      # CircleCI maintains a library of pre-built images
-      # documented at https://circleci.com/docs/2.0/circleci-images/
-      # - image: circleci/postgres:9.4
+      - image: circleci/python:3.7.4
 
     working_directory: ~/gptorch
 
     steps:
       - checkout
 
-      # Download and cache dependencies
       - restore_cache:
           keys:
             - v1-dependencies-{{ checksum "requirements.txt" }}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,12 +40,11 @@ jobs:
             - ./venv
           key: v1-dependencies-{{ checksum "requirements.txt" }}
 
-      # run tests!
       - run:
           name: Run tests
           command: |
             . venv/bin/activate
-            pytest --cov-report html --cov=convert test/
+            pytest --cov-report html --cov=gptorch test/
       - store_artifacts:
           path: htmlcov
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+Current version on PyPI: 0.2.1
+
+# 0.2.2:
+* Remove instances of torch.set_default_dtype() from codebase
+* Add CircleCI and CodeCov.io

--- a/CHANGELOG_0.2.2.txt
+++ b/CHANGELOG_0.2.2.txt
@@ -1,0 +1,1 @@
+* Remove instances of torch.set_default_dtype() from codebase

--- a/CHANGELOG_0.2.2.txt
+++ b/CHANGELOG_0.2.2.txt
@@ -1,1 +1,0 @@
-* Remove instances of torch.set_default_dtype() from codebase

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # gptorch
+[![CircleCI](https://circleci.com/gh/cics-nd/gptorch.svg?style=svg)](https://circleci.com/gh/cics-nd/gptorch)
+[![codecov](https://codecov.io/gh/cics-nd/gptorch/branch/master/graph/badge.svg)](https://codecov.io/gh/cics-nd/gptorch)
 Gaussian processes with PyTorch
 
 ## Installation

--- a/codecov.yml
+++ b/codecov.yml
@@ -2,7 +2,7 @@ coverage:
   status:
     project:
       default:
-        target: 90%
+        target: 70%
         threshold: 1%
 
 ignore:

--- a/gptorch/models/gpr.py
+++ b/gptorch/models/gpr.py
@@ -10,7 +10,6 @@ Class for Vanilla GP regression.
 from __future__ import absolute_import
 import torch
 import numpy as np
-from torch.autograd import Variable
 
 from .. import kernels
 from ..model import GPModel, Param
@@ -29,11 +28,11 @@ class GPR(GPModel):
         Default likelihood is Gaussain, mean function is zero.
 
         Args:
-            observations (np.ndarray or Variable): a matrix of observed outputs.
+            observations (np.ndarray or TensorType): a matrix of observed outputs.
                 Each datum is a row in the matrix (# rows = # training data,
                 # columns = output dimensionality)
-            input (np.ndarray or Variable): the observed inputs.
-                If input is a numpy matrix or torch Variable, then each datum is
+            input (np.ndarray or TensorType): the observed inputs.
+                If input is a numpy matrix or torch TensorType, then each datum is
                 a row in the matrix (# rows = # training data,
                 # columns = input dimensionality).
             kernel (Kernel): The kernel function for computing the covariance
@@ -69,7 +68,7 @@ class GPR(GPModel):
         Computes the covariance matrix over the training inputs
 
         Returns:
-            Ky (torch.Tensor)
+            Ky (TensorType)
         """
         num_input = self.Y.size(0)
 

--- a/test/test_base.py
+++ b/test/test_base.py
@@ -1,0 +1,17 @@
+
+"""
+Basic tests for the repo
+"""
+
+
+def test_torch_dtype():
+    """
+    Ensure that importing gptorch does not change the default dtype for torch.
+    """
+
+    import torch
+    dtype = torch.get_default_dtype()
+    import gptorch
+    new_dtype = torch.get_default_dtype()
+
+    assert new_dtype == dtype


### PR DESCRIPTION
`torch.set_default_dtype()` seems to have a global effect. When used internally in modules, this causes surprising behaviors when using gptorch alongside other PyTorch code that uses other dtypes.

This PR removes those instances in simply uses `util.TensorType` instead to prevent external effects.