### PR TITLE
fix ValueError: invalid literal for int() with base 10

### DIFF
--- a/gptorch/functions.py
+++ b/gptorch/functions.py
@@ -10,7 +10,7 @@ import torch
 from torch.nn import functional as F
 import numpy as np
 
-torch_version = [int(s) for s in torch.__version__.split(".")]
+torch_version = [int(s) for s in torch.__version__.replace("+",".").split('.') if s.isdigit()]
 _potri = torch.cholesky_inverse if torch_version >= [1, 1, 0] else torch.potri
     
 


### PR DESCRIPTION
I added the fix to this problem.
![ValueError](https://user-images.githubusercontent.com/15808937/87245162-7e5b7f80-c443-11ea-8855-66770f235c4c.PNG)
